### PR TITLE
Add flashing effect to body part indicators in Medical GUI

### DIFF
--- a/addons/medical_gui/functions/fnc_displayPatientInformation.sqf
+++ b/addons/medical_gui/functions/fnc_displayPatientInformation.sqf
@@ -47,6 +47,10 @@ if (isNull _display) then {
         private _ctrlBodyImage = _display displayCtrl IDC_BODY_GROUP;
         [_ctrlBodyImage, _target] call FUNC(updateBodyImage);
 
+        // Update flash values
+        private _deltaTime = GVAR(camDeltaTime);
+        [_ctrlBodyImage, _deltaTime] call FUNC(updateFlashValues);
+        
         // Update injury list
         private _ctrlInjuries = _display displayCtrl IDC_INJURIES;
         [_ctrlInjuries, _target, _selectionN] call FUNC(updateInjuryList);

--- a/addons/medical_gui/functions/fnc_updateBodyImage.sqf
+++ b/addons/medical_gui/functions/fnc_updateBodyImage.sqf
@@ -23,6 +23,9 @@ private _tourniquets = GET_TOURNIQUETS(_target);
 private _fractures = GET_FRACTURES(_target);
 private _bodyPartDamage = _target getVariable [QEGVAR(medical,bodyPartDamage), [0, 0, 0, 0, 0, 0]];
 private _bodyPartBloodLoss = [0, 0, 0, 0, 0, 0];
+private _previousDamage = _ctrlGroup getVariable ["ace_medical_gui_previousDamage", [0, 0, 0, 0, 0, 0]];
+_ctrlGroup setVariable ["ace_medical_gui_previousDamage", _bodyPartDamage];
+
 
 {
     _x params ["", "_bodyPartN", "_amountOf", "_bleeding"];
@@ -68,6 +71,13 @@ private _bodyPartBloodLoss = [0, 0, 0, 0, 0, 0];
     } else {
         private _damage = _bodyPartDamage select _forEachIndex;
         [_damage] call FUNC(damageToRGBA);
+    };
+
+    private _previousBodyPartDamage = _previousDamage select _forEachIndex;
+    private _currentBodyPartDamage = _bodyPartDamage select _forEachIndex;
+    if (_currentBodyPartDamage > _previousBodyPartDamage) then {
+        private _flashIntensity = 1; // Set flash intensity (0 to 1)
+        GVAR(bodyPartFlashArray) set [_forEachIndex, [_bodyPartIDC, _flashIntensity]];
     };
 
     private _ctrlBodyPart = _ctrlGroup controlsGroupCtrl _bodyPartIDC;

--- a/addons/medical_gui/functions/fnc_updateFlashValues.sqf
+++ b/addons/medical_gui/functions/fnc_updateFlashValues.sqf
@@ -1,0 +1,26 @@
+#include "script_component.hpp"
+
+params ["_ctrlGroup", "_deltaTime"];
+
+private _flashSpeed = 4; // Increase this value to make the flash fade faster
+private _maxFlashIntensity = 1; // Set the maximum flash intensity (0 to 1)
+
+// Iterate through the body parts and update the flash value
+{
+    _x params ["_bodyPartIDC", "_flashIntensity"];
+    private _ctrlBodyPart = _ctrlGroup controlsGroupCtrl _bodyPartIDC;
+
+    // Reduce the flash intensity based on delta time and speed
+    _flashIntensity = _flashIntensity - (_deltaTime * _flashSpeed);
+
+    // Clamp the flash intensity between 0 and _maxFlashIntensity
+    _flashIntensity = _flashIntensity max 0 min _maxFlashIntensity;
+
+    // Update the flash intensity in the body part's flash array
+    GVAR(bodyPartFlashArray) set [_forEachIndex, [_bodyPartIDC, _flashIntensity]];
+
+    // Update the body part color based on flash intensity
+    private _baseColor = _ctrlBodyPart getVariable "ace_medical_gui_baseColor";
+    private _flashedColor = [_baseColor, _flashIntensity] call FUNC(mixColors);
+    _ctrlBodyPart ctrlSetTextColor _flashedColor;
+} forEach GVAR(bodyPartFlashArray);


### PR DESCRIPTION
**Description:**

This pull request introduces a flashing effect for body part indicators in the Medical GUI to represent the worsening state of the body part. The effect is achieved by quickly pulsing the body part icon within a 0.5-second duration to visualize the change. The flashing effect will only occur once for rapidly changing values and is designed to improve user experience when monitoring patients.

**Main changes:**

- Added ace_medical_gui_fnc_updateFlashValues function to handle flashing effects based on the current state of the body part.
- Modified ace_medical_gui_fnc_updateBodyImage to store the previous state of the body part to detect worsening conditions.
- Updated ace_medical_gui_fnc_displayPatientInformation to call the ace_medical_gui_fnc_updateFlashValues function and use GVAR(camDeltaTime) for delta time calculations.

This feature enhances the Medical GUI by providing better visual feedback for players, making it easier to identify the worsening state of a patient's body part during treatment.